### PR TITLE
Module name bug passes tests, but prevents manual compilation

### DIFF
--- a/src/main/java/de/uni/bremen/monty/moco/ast/ASTBuilder.java
+++ b/src/main/java/de/uni/bremen/monty/moco/ast/ASTBuilder.java
@@ -79,8 +79,8 @@ public class ASTBuilder extends MontyBaseVisitor<ASTNode> {
 	public ASTNode visitModuleDeclaration(@NotNull MontyParser.ModuleDeclarationContext ctx) {
 		Block block = new Block(position(ctx.getStart()));
 		ModuleDeclaration module =
-		        new ModuleDeclaration(position(ctx.getStart()),
-		                new Identifier(FilenameUtils.removeExtension(fileName)), block, new ArrayList<Import>());
+		        new ModuleDeclaration(position(ctx.getStart()), new Identifier(FilenameUtils.getBaseName(fileName)),
+		                block, new ArrayList<Import>());
 		currentBlocks.push(block);
 
 		for (MontyParser.ImportLineContext imp : ctx.importLine()) {


### PR DESCRIPTION
in commit bbece7a2eb24ad833bc366a010be21bc50077a22 the name generation for a module was changed in ``ASTBuilder.visitModuleDeclaration`` such that the file extension is omitted.
Although this change is reasonable, it leads to a strange bug which produces an error, whenever a Monty file is compiled. Even more strange is the fact, that all integration tests pass, while the manual compilation via ``java -jar moco-0.6.jar -e test.monty`` always fails, even for a simple hello world program. The following error message is produced:

````
de.uni.bremen.monty.moco.exception.NotYetImplementedException: "M.corelib/Array.C.Array.F.length$M.corelib/Int.C.Int" is not defined yet
        at de.uni.bremen.monty.moco.codegeneration.voodoo.BlackMagic.generateNativeFunction(BlackMagic.java:73)
        at de.uni.bremen.monty.moco.codegeneration.CodeGenerator.addNativeFunction(CodeGenerator.java:306)
        at de.uni.bremen.monty.moco.visitor.CodeGenerationVisitor.addNativeFunction(CodeGenerationVisitor.java:149)
        at de.uni.bremen.monty.moco.visitor.CodeGenerationVisitor.visit(CodeGenerationVisitor.java:543)
        at de.uni.bremen.monty.moco.ast.declaration.FunctionDeclaration.visit(FunctionDeclaration.java:118)
        at de.uni.bremen.monty.moco.visitor.BaseVisitor.visitDoubleDispatched(BaseVisitor.java:72)
        at de.uni.bremen.monty.moco.visitor.CodeGenerationVisitor.visit(CodeGenerationVisitor.java:182)
        at de.uni.bremen.monty.moco.ast.Block.visit(Block.java:106)
        at de.uni.bremen.monty.moco.visitor.BaseVisitor.visitDoubleDispatched(BaseVisitor.java:72)
        at de.uni.bremen.monty.moco.visitor.CodeGenerationVisitor.visit(CodeGenerationVisitor.java:207)
        at de.uni.bremen.monty.moco.ast.declaration.ClassDeclaration.visit(ClassDeclaration.java:184)
        at de.uni.bremen.monty.moco.visitor.BaseVisitor.visitDoubleDispatched(BaseVisitor.java:72)
        at de.uni.bremen.monty.moco.visitor.CodeGenerationVisitor.visit(CodeGenerationVisitor.java:182)
        at de.uni.bremen.monty.moco.ast.Block.visit(Block.java:106)
        at de.uni.bremen.monty.moco.visitor.BaseVisitor.visitDoubleDispatched(BaseVisitor.java:72)
        at de.uni.bremen.monty.moco.ast.declaration.ModuleDeclaration.visitChildren(ModuleDeclaration.java:99)
        at de.uni.bremen.monty.moco.visitor.BaseVisitor.visit(BaseVisitor.java:128)
        at de.uni.bremen.monty.moco.ast.Package.visitChildren(Package.java:77)
        at de.uni.bremen.monty.moco.visitor.BaseVisitor.visit(BaseVisitor.java:435)
        at de.uni.bremen.monty.moco.visitor.CodeGenerationVisitor.visit(CodeGenerationVisitor.java:175)
        at de.uni.bremen.monty.moco.ast.Package.visitChildren(Package.java:74)
        at de.uni.bremen.monty.moco.visitor.BaseVisitor.visit(BaseVisitor.java:435)
        at de.uni.bremen.monty.moco.visitor.CodeGenerationVisitor.visit(CodeGenerationVisitor.java:170)
        at de.uni.bremen.monty.moco.ast.Package.visit(Package.java:68)
        at de.uni.bremen.monty.moco.visitor.BaseVisitor.visitDoubleDispatched(BaseVisitor.java:72)
        at de.uni.bremen.monty.moco.Main.visitVisitors(Main.java:127)
        at de.uni.bremen.monty.moco.Main.main(Main.java:246)
````

it seems that the module name change confuses the NameMangler, since a method ``M.corelib/Array.C.Array.F.length$M.corelib/Int.C.Int`` is looked for, while the correct name is ``M.Array.C.Array.F.length$M.Int.C.Int``.

This merge request reverts the module name change in order to keep moco working.