### PR TITLE
Optional access modifiers

### DIFF
--- a/src/main/antlr4/de/uni/bremen/monty/moco/antlr/Monty.g4
+++ b/src/main/antlr4/de/uni/bremen/monty/moco/antlr/Monty.g4
@@ -30,7 +30,7 @@ classDeclaration
   ;
 
 memberDeclaration
-  : accessModifier independentDeclaration
+  : accessModifier? independentDeclaration
   ;
 
 accessModifier

--- a/src/main/java/de/uni/bremen/monty/moco/ast/ASTBuilder.java
+++ b/src/main/java/de/uni/bremen/monty/moco/ast/ASTBuilder.java
@@ -79,8 +79,8 @@ public class ASTBuilder extends MontyBaseVisitor<ASTNode> {
 	public ASTNode visitModuleDeclaration(@NotNull MontyParser.ModuleDeclarationContext ctx) {
 		Block block = new Block(position(ctx.getStart()));
 		ModuleDeclaration module =
-		        new ModuleDeclaration(position(ctx.getStart()),
-		                new Identifier(FilenameUtils.removeExtension(fileName)), block, new ArrayList<Import>());
+		        new ModuleDeclaration(position(ctx.getStart()), new Identifier(FilenameUtils.getBaseName(fileName)),
+		                block, new ArrayList<Import>());
 		currentBlocks.push(block);
 
 		for (MontyParser.ImportLineContext imp : ctx.importLine()) {

--- a/src/main/java/de/uni/bremen/monty/moco/ast/ASTBuilder.java
+++ b/src/main/java/de/uni/bremen/monty/moco/ast/ASTBuilder.java
@@ -300,7 +300,17 @@ public class ASTBuilder extends MontyBaseVisitor<ASTNode> {
 			if (astNode instanceof Declaration) {
 
 				Declaration decl = (Declaration) astNode;
-				decl.setAccessModifier(AccessModifier.stringToAccess(member.accessModifier().modifier.getText()));
+				AccessModifierContext modifierCtx = member.accessModifier();
+
+				// access modifiers are optional
+				if (modifierCtx != null) {
+					decl.setAccessModifier(AccessModifier.stringToAccess(modifierCtx.modifier.getText()));
+				}
+				// if none is given, the default accessibility is "package"
+				else {
+					decl.setAccessModifier(AccessModifier.stringToAccess("~"));
+				}
+
 				cl.getBlock().addDeclaration(decl);
 			} else if (astNode instanceof Assignment) {
 

--- a/src/main/java/de/uni/bremen/monty/moco/ast/ASTBuilder.java
+++ b/src/main/java/de/uni/bremen/monty/moco/ast/ASTBuilder.java
@@ -308,7 +308,7 @@ public class ASTBuilder extends MontyBaseVisitor<ASTNode> {
 				}
 				// if none is given, the default accessibility is "package"
 				else {
-					decl.setAccessModifier(AccessModifier.stringToAccess("~"));
+					decl.setAccessModifier(AccessModifier.PACKAGE);
 				}
 
 				cl.getBlock().addDeclaration(decl);


### PR DESCRIPTION
Making access modifiers optional (default is package "~")
    
The specification says that an access modifier may be specified. If none is given, the particular attribute is only visible inside the same package. However, this now works only syntactically, since the semantics of access modifiers remain unimplemented.