### PR TITLE
Fix ControlFlowVisitor bug

### DIFF
--- a/src/main/java/de/uni/bremen/monty/moco/visitor/ControlFlowVisitor.java
+++ b/src/main/java/de/uni/bremen/monty/moco/visitor/ControlFlowVisitor.java
@@ -96,6 +96,7 @@ public class ControlFlowVisitor extends BaseVisitor {
 		boolean needsReturnStatementCopy = needsReturnStatement;
 		visitDoubleDispatched(node.getThenBlock());
 		boolean needsReturnStatementCopyThen = needsReturnStatement;
+		this.needsReturnStatement = needsReturnStatementCopy;
 		visitDoubleDispatched(node.getElseBlock());
 		boolean needsReturnStatementCopyElse = needsReturnStatement;
 


### PR DESCRIPTION
The following code fragment would not have been marked illegal by the current ControlFlowVisitor though there is no return in the else branch:

```
String foo(Bool cond):
    if cond:
        return "a"
```