### PR TITLE
Moving tuples to the core library

### DIFF
--- a/src/main/java/de/uni/bremen/monty/moco/ast/ASTBuilder.java
+++ b/src/main/java/de/uni/bremen/monty/moco/ast/ASTBuilder.java
@@ -89,10 +89,10 @@ public class ASTBuilder extends MontyBaseVisitor<ASTNode> {
 		}
 	};
 
-	public ASTBuilder(String fileName) {
+	public ASTBuilder(String fileName, TupleDeclarationFactory tupleDeclarationFactory) {
 		this.fileName = fileName;
 		currentBlocks = new Stack<>();
-		tupleDeclarationFactory = new TupleDeclarationFactory();
+		this.tupleDeclarationFactory = tupleDeclarationFactory;
 	}
 
 	private Position position(Token idSymbol) {
@@ -123,9 +123,6 @@ public class ASTBuilder extends MontyBaseVisitor<ASTNode> {
 		}
 		addStatementsToBlock(block, ctx.statement());
 		currentBlocks.pop();
-		for (ClassDeclaration decl : tupleDeclarationFactory.getTupleTypes()) {
-			module.getBlock().addDeclaration(decl);
-		}
 		return module;
 	}
 
@@ -687,8 +684,8 @@ public class ASTBuilder extends MontyBaseVisitor<ASTNode> {
 				elements.add((Expression) visit(eContext));
 			}
 			// generate a new tuple type if necessary
-			ClassDeclaration tupleType = tupleDeclarationFactory.getTupleType(elements.size());
-			TupleLiteral tuple = new TupleLiteral(position(ctx.getStart()), tupleType, elements);
+			tupleDeclarationFactory.checkTupleType(elements.size());
+			TupleLiteral tuple = new TupleLiteral(position(ctx.getStart()), elements);
 			return tuple;
 		} else {
 			return new BooleanLiteral(position(ctx.getStart()), Boolean.parseBoolean(ctx.BooleanLiteral().toString()));

--- a/src/main/java/de/uni/bremen/monty/moco/ast/AntlrAdapter.java
+++ b/src/main/java/de/uni/bremen/monty/moco/ast/AntlrAdapter.java
@@ -42,6 +42,7 @@ package de.uni.bremen.monty.moco.ast;
 import de.uni.bremen.monty.moco.antlr.MontyLexer;
 import de.uni.bremen.monty.moco.antlr.MontyParser;
 import de.uni.bremen.monty.moco.ast.declaration.ModuleDeclaration;
+import de.uni.bremen.monty.moco.util.TupleDeclarationFactory;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 
@@ -51,6 +52,7 @@ import java.io.InputStream;
 import java.io.SequenceInputStream;
 
 public class AntlrAdapter {
+	private TupleDeclarationFactory tupleDeclarationFactory = new TupleDeclarationFactory();
 
 	public MontyParser createParser(final InputStream file) throws IOException {
 
@@ -71,8 +73,12 @@ public class AntlrAdapter {
 	public ModuleDeclaration parse(InputStream file, String fileName) throws IOException {
 		MontyParser parser = createParser(file);
 
-		ASTBuilder astBuilder = new ASTBuilder(fileName);
+		ASTBuilder astBuilder = new ASTBuilder(fileName, tupleDeclarationFactory);
 		ASTNode moduleNode = astBuilder.visit(parser.compilationUnit());
 		return (ModuleDeclaration) moduleNode;
+	}
+
+	public TupleDeclarationFactory getTupleDeclarationFactory() {
+		return tupleDeclarationFactory;
 	}
 }

--- a/src/main/java/de/uni/bremen/monty/moco/ast/PackageBuilder.java
+++ b/src/main/java/de/uni/bremen/monty/moco/ast/PackageBuilder.java
@@ -61,9 +61,9 @@ public class PackageBuilder {
 
 	private Package buildPackage(MontyResource inputFile) {
 		Package basePackage = new Package(new Identifier(""));
-		addCoreLib(basePackage);
 		Package subPackage = (inputFile.isDirectory()) ? createPackage(inputFile) : createPackageFromFile(inputFile);
 		basePackage.addSubPackage(subPackage);
+		addCoreLib(basePackage);
 		return basePackage;
 	}
 
@@ -79,6 +79,21 @@ public class PackageBuilder {
 		block.addDeclaration(CoreClasses.voidType());
 		corePackage.addModule(module);
 		setCoreClasses(corePackage);
+
+		ModuleDeclaration tupleModule = null;
+		for (ModuleDeclaration tmodule : corePackage.getModules()) {
+			if (tmodule.getIdentifier().getSymbol().equals("Tuple")) {
+				tupleModule = tmodule;
+				break;
+			}
+		}
+		if (tupleModule == null) {
+			throw new RuntimeException("Error, no Tuple module in core library!");
+		}
+
+		for (ClassDeclaration tupleDecl : antlrAdapter.getTupleDeclarationFactory().generateNecessaryTupleTypes()) {
+			tupleModule.getBlock().addDeclaration(tupleDecl);
+		}
 	}
 
 	private void setCoreClasses(Package corePackage) {

--- a/src/main/java/de/uni/bremen/monty/moco/ast/expression/literal/TupleLiteral.java
+++ b/src/main/java/de/uni/bremen/monty/moco/ast/expression/literal/TupleLiteral.java
@@ -46,32 +46,23 @@ import de.uni.bremen.monty.moco.ast.expression.*;
 import java.util.ArrayList;
 
 public class TupleLiteral extends FunctionCall {
-
-	private final ClassDeclaration genericTupleClass;
-
 	/** Constructor.
 	 *
 	 * @param position
 	 *            Position of this node
 	 * @param entries */
-	public TupleLiteral(Position position, ClassDeclaration genericTupleClass, ArrayList<Expression> entries) {
-		super(position, new ResolvableIdentifier("Tuple" + entries.size(), new ArrayList<ResolvableIdentifier>()),
-		        entries);
-		this.genericTupleClass = genericTupleClass;
+	public TupleLiteral(Position position, ArrayList<Expression> entries) {
+		super(position, new ResolvableIdentifier("Tuple" + entries.size(), new ArrayList<ResolvableIdentifier>(
+		        entries.size())), entries);
 	}
 
 	public void setConcreteTupleType() {
-		ArrayList<ClassDeclaration> concreteTypes = new ArrayList<>(arguments.size());
 		for (Expression entry : arguments) {
 			if (entry.getType() instanceof ClassDeclaration) {
-				concreteTypes.add((ClassDeclaration) entry.getType());
 				getIdentifier().getGenericTypes().add(ResolvableIdentifier.convert(entry.getType().getIdentifier()));
 			} else {
 				throw new RuntimeException("TYPE:: " + entry.getType());
 			}
 		}
-		setType(genericTupleClass.getVariation(
-		        ResolvableIdentifier.convert(genericTupleClass.getIdentifier()),
-		        concreteTypes));
 	}
 }

--- a/src/main/java/de/uni/bremen/monty/moco/util/TupleDeclarationFactory.java
+++ b/src/main/java/de/uni/bremen/monty/moco/util/TupleDeclarationFactory.java
@@ -53,19 +53,10 @@ import java.util.*;
 
 /** This class bundles utilities for the automatic generation of types at compile-time */
 public class TupleDeclarationFactory {
-	private Map<Integer, ClassDeclaration> tupleTypes = new HashMap<>();
+	private Set<Integer> tupleTypes = new HashSet<>();
 
-	/** Introduces a new type TupleN if it was not already created. Returns the tuple type.
-	 *
-	 * @param n */
-	public ClassDeclaration getTupleType(int n) {
-		// lookup a TupleN, if it was not found, generate the class
-		ClassDeclaration tupleType = tupleTypes.get(n);
-		if (tupleType == null) {
-			tupleType = createTupleType(n);
-			tupleTypes.put(n, tupleType);
-		}
-		return tupleType;
+	public void checkTupleType(int n) {
+		tupleTypes.add(n);
 	}
 
 	/** This method checks whether the given Identifier is a tuple type. If yes, a new tuple type is introduced, given
@@ -77,7 +68,7 @@ public class TupleDeclarationFactory {
 		if (str.startsWith("Tuple")) {
 			String number = str.substring(5);
 			try {
-				getTupleType(Integer.parseInt(number));
+				checkTupleType(Integer.parseInt(number));
 			} catch (Exception e) {
 				// if the rest is not a number, we don't need to create a tuple type
 			}
@@ -144,7 +135,11 @@ public class TupleDeclarationFactory {
 		                new VariableAccess(new Position(), ResolvableIdentifier.convert(param.getIdentifier()))));
 	}
 
-	public Collection<ClassDeclaration> getTupleTypes() {
-		return tupleTypes.values();
+	public Collection<ClassDeclaration> generateNecessaryTupleTypes() {
+		Collection<ClassDeclaration> tupleClasses = new ArrayList<>(tupleTypes.size());
+		for (int n : tupleTypes) {
+			tupleClasses.add(createTupleType(n));
+		}
+		return tupleClasses;
 	}
 }

--- a/src/main/java/de/uni/bremen/monty/moco/visitor/ResolveVisitor.java
+++ b/src/main/java/de/uni/bremen/monty/moco/visitor/ResolveVisitor.java
@@ -314,7 +314,7 @@ public class ResolveVisitor extends VisitOnceVisitor {
 			ResolvableIdentifier identifier = node.getIdentifier();
 			if (classDecl.isAbstract()) {
 				throw new InvalidExpressionException(node, "The abstract class '" + identifier.toString()
-				        + "' may not be instantiated");
+				        + "' must not be instantiated");
 			}
 			node.setType(classDecl);
 			ProcedureDeclaration initializer = findMatchingInitializer(node, classDecl);

--- a/src/test/java/de/uni/bremen/monty/moco/ast/ASTBuilderTest.java
+++ b/src/test/java/de/uni/bremen/monty/moco/ast/ASTBuilderTest.java
@@ -48,6 +48,7 @@ import de.uni.bremen.monty.moco.ast.expression.literal.IntegerLiteral;
 import de.uni.bremen.monty.moco.ast.expression.literal.StringLiteral;
 import de.uni.bremen.monty.moco.ast.statement.Assignment;
 import de.uni.bremen.monty.moco.ast.statement.ConditionalStatement;
+import de.uni.bremen.monty.moco.util.TupleDeclarationFactory;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.apache.commons.io.FileUtils;
@@ -249,7 +250,7 @@ public class ASTBuilderTest {
 	}
 
 	private ModuleDeclaration buildAST(String fileName, MontyParser parser) {
-		ASTBuilder astBuilder = new ASTBuilder(fileName);
+		ASTBuilder astBuilder = new ASTBuilder(fileName, new TupleDeclarationFactory());
 		ASTNode rootNode = astBuilder.visitModuleDeclaration(parser.moduleDeclaration());
 		return (ModuleDeclaration) rootNode;
 	}

--- a/src/test/resources/testPrograms/negativ/classes/AbstractClassInstantiation.error
+++ b/src/test/resources/testPrograms/negativ/classes/AbstractClassInstantiation.error
@@ -1,1 +1,1 @@
-ResolveVisitor caught error in FunctionCall at file: AbstractClassInstantiation.monty, line: 4, char: 17: The abstract class 'Logger' may not be instantiated
+ResolveVisitor caught error in FunctionCall at file: AbstractClassInstantiation.monty, line: 4, char: 17: The abstract class 'Logger' must not be instantiated


### PR DESCRIPTION
In the prior implementation of tuples the tuple type declarations were added
to the current module, which worked good if the tuples only were used inside
that module. Since tuples are core types, they should be located inside the
core library. This also allows the core library to use tuple types.